### PR TITLE
Add web UI and single-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ This proof of concept demonstrates a basic message pipeline using Spring Boot 3.
      -d '{"content":"hello"}' http://localhost:8080/api/messages
    ```
 
+4. Try the simple web UI at `http://localhost:8080/index.html`. Press **Start**
+   to send one request per second for 12 seconds and watch the counter and
+   elapsed time update live.
+
+5. Alternatively, run the `SingleRun.java` script which performs the same test
+   from the command line:
+   ```bash
+   cd rabbitmq-poc
+   java SingleRun.java
+   ```
+
 ### Load Test
 To approximate 200 transactions per second:
 ```bash

--- a/rabbitmq-poc/SingleRun.java
+++ b/rabbitmq-poc/SingleRun.java
@@ -1,0 +1,30 @@
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class SingleRun {
+    public static void main(String[] args) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        String auth = Base64.getEncoder()
+                .encodeToString("user:password".getBytes(StandardCharsets.UTF_8));
+        long end = System.currentTimeMillis() + 12_000;
+        int count = 0;
+        while (System.currentTimeMillis() < end) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:8080/api/messages"))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Basic " + auth)
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"content\":\"hello\"}"))
+                    .build();
+            long start = System.currentTimeMillis();
+            HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+            long duration = System.currentTimeMillis() - start;
+            System.out.printf("Request %d -> %d (%d ms)%n", ++count, response.statusCode(), duration);
+            Thread.sleep(1000);
+        }
+        System.out.println("Total requests: " + count);
+    }
+}

--- a/rabbitmq-poc/src/main/resources/static/index.html
+++ b/rabbitmq-poc/src/main/resources/static/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>RabbitMQ POC</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 2em; }
+#log { border: 1px solid #ccc; padding: 1em; height: 200px; overflow-y: auto; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+<h1>RabbitMQ POC</h1>
+<button id="startBtn">Start</button>
+<p>Requests sent: <span id="count">0</span></p>
+<p>Elapsed: <span id="timer">0</span>s</p>
+<div id="log"></div>
+<script>
+const btn = document.getElementById('startBtn');
+const countSpan = document.getElementById('count');
+const timerSpan = document.getElementById('timer');
+const logDiv = document.getElementById('log');
+
+btn.addEventListener('click', () => {
+  let count = 0;
+  let seconds = 0;
+  countSpan.textContent = '0';
+  timerSpan.textContent = '0';
+  logDiv.textContent = '';
+  const auth = btoa('user:password');
+  const sendInterval = setInterval(() => {
+    fetch('/api/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Basic ' + auth
+      },
+      body: JSON.stringify({content: 'hello ' + count})
+    }).then(() => {
+      count++;
+      countSpan.textContent = String(count);
+      logDiv.textContent += `Sent request ${count}\n`;
+    }).catch(err => {
+      logDiv.textContent += `Error: ${err}\n`;
+    });
+  }, 1000);
+
+  const timer = setInterval(() => {
+    seconds++;
+    timerSpan.textContent = String(seconds);
+    if (seconds >= 12) {
+      clearInterval(sendInterval);
+      clearInterval(timer);
+    }
+  }, 1000);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an HTML page served by Spring Boot to manually send test requests
- provide a SingleRun.java script for quick command-line testing
- document using the new web UI and script in the README

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_b_68659c69e7c083249e84c740726c477e