### PR TITLE
Update Windows notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,7 @@ Basic authentication is enabled with a default user (`user`/`password`). Update 
 - `docker-compose.yml` – RabbitMQ and PostgreSQL services
 - `loadtest.sh` – helper script for a simple benchmark
 
+## Windows notes
+- Ensure Docker Desktop is installed and running (with WSL 2 if enabled) before executing `docker-compose`.
+
 This setup is intended for experimentation and should be tuned and hardened before any production use.


### PR DESCRIPTION
## Summary
- add a Windows notes section
- mention Docker Desktop must be running before using `docker-compose`

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_b_6865a61a69b88324a4ce2ea57c8b989a