### PR TITLE
Update README for docker-compose path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This proof of concept demonstrates a basic message pipeline using Spring Boot 3.
 
 1. Start the infrastructure:
    ```bash
+   cd rabbitmq-poc
    docker-compose up -d
    ```
-2. Build and run the application:
+2. Build and run the application from the same directory:
    ```bash
-   cd rabbitmq-poc
    ./mvnw spring-boot:run
    ```
 3. Send a test request:


### PR DESCRIPTION
## Summary
- document that infrastructure setup runs from inside `rabbitmq-poc/`
- adjust instructions so subsequent steps assume you're already in the directory

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6865a612d3948324b89ef97d91dd1552