### PR TITLE
Fix Kotlin Spring config build issue

### DIFF
--- a/rabbitmq-poc/pom.xml
+++ b/rabbitmq-poc/pom.xml
@@ -99,6 +99,11 @@
                                                 </goals>
                                         </execution>
                                 </executions>
+                                <configuration>
+                                        <compilerPlugins>
+                                                <plugin>spring</plugin>
+                                        </compilerPlugins>
+                                </configuration>
                         </plugin>
                         <plugin>
                                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- enable the `spring` compiler plugin for Kotlin

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6865b16ad08883249ef170512cd5bd42